### PR TITLE
Command line argument support

### DIFF
--- a/src/process_forest.py
+++ b/src/process_forest.py
@@ -44,12 +44,8 @@ class Process(object):
         self.id = None  # set by analyzer, unique with analyzer session
 
     def __str__(self):
-        if self.cmdline == "":
-            cmdl = ""
-        else:
-            cmdl = " " + "\"" + self.cmdline + "\""
-        return "Process(%s%s, pid=%x, ppid=%x, begin=%s, end=%s" % (
-                self.path, cmdl, self.pid, self.ppid,
+        return "Process(%s, cmd=%s, pid=%x, ppid=%x, begin=%s, end=%s" % (
+                self.path, self.cmdline, self.pid, self.ppid,
                 self.begin.isoformat(), self.end.isoformat())
 
     # TODO: move serialize, deserialize here

--- a/src/process_forest.py
+++ b/src/process_forest.py
@@ -93,7 +93,7 @@ class Entry(object):
         pid = int(self.get_xpath("/Event/EventData/Data[@Name='NewProcessId']").text, 0x10)
         ppid = int(self.get_xpath("/Event/EventData/Data[@Name='ProcessId']").text, 0x10)
         try:
-            cmdline = self.get_xpath("/Event/EventData/Data[@Name='CommandLine']
+            cmdline = self.get_xpath("/Event/EventData/Data[@Name='CommandLine']").text
         except:
             cmdline = ""
         user = self.get_xpath("/Event/EventData/Data[@Name='SubjectUserName']").text

--- a/src/process_forest.py
+++ b/src/process_forest.py
@@ -26,11 +26,12 @@ def to_lxml(record_xml):
 class Process(object):
     NOTE_FAKE_PARENT = "Fake Parent: This is a faked process created since a ppid didn't exist"
     NOTE_END_LOST = "Lost End Timestamp: This end timestamp is suspect, because it collided with another process"
-    def __init__(self, pid, ppid, path, user, domain, logonid, computer):
+    def __init__(self, pid, ppid, cmdline, path, user, domain, logonid, computer):
         super(Process, self).__init__()
         self.pid = pid
         self.ppid = ppid
         self.path = path
+        self.cmdline = cmdline
         self.user = user
         self.domain = domain
         self.logonid = logonid
@@ -43,15 +44,19 @@ class Process(object):
         self.id = None  # set by analyzer, unique with analyzer session
 
     def __str__(self):
-        return "Process(%s, pid=%x, ppid=%x, begin=%s, end=%s" % (
-                self.path, self.pid, self.ppid,
+        if self.cmdline == "":
+            cmdl = ""
+        else:
+            cmdl = " " + "\"" + self.cmdline + "\""
+        return "Process(%s%s, pid=%x, ppid=%x, begin=%s, end=%s" % (
+                self.path, cmdl, self.pid, self.ppid,
                 self.begin.isoformat(), self.end.isoformat())
 
     # TODO: move serialize, deserialize here
 
 
 def create_fake_parent_process(pid):
-    p = Process(pid, 0, "UNKNOWN", "UNKNOWN", "UNKNOWN", "UNKNOWN", "UNKNOWN")
+    p = Process(pid, 0, "", "UNKNOWN", "UNKNOWN", "UNKNOWN", "UNKNOWN", "UNKNOWN")
     p.notes = Process.NOTE_FAKE_PARENT
     return p
 
@@ -87,11 +92,15 @@ class Entry(object):
         path = self.get_xpath("/Event/EventData/Data[@Name='NewProcessName']").text
         pid = int(self.get_xpath("/Event/EventData/Data[@Name='NewProcessId']").text, 0x10)
         ppid = int(self.get_xpath("/Event/EventData/Data[@Name='ProcessId']").text, 0x10)
+        try:
+            cmdline = self.get_xpath("/Event/EventData/Data[@Name='CommandLine']
+        except:
+            cmdline = ""
         user = self.get_xpath("/Event/EventData/Data[@Name='SubjectUserName']").text
         domain = self.get_xpath("/Event/EventData/Data[@Name='SubjectDomainName']").text
         logonid = self.get_xpath("/Event/EventData/Data[@Name='SubjectLogonId']").text
         computer = self.get_xpath("/Event/System/Computer").text
-        p = Process(pid, ppid, path, user, domain, logonid, computer)
+        p = Process(pid, ppid, cmdline, path, user, domain, logonid, computer)
         p.begin = self._record.timestamp()
         return p
 
@@ -99,11 +108,12 @@ class Entry(object):
         path = self.get_xpath("/Event/EventData/Data[@Name='ProcessName']").text
         pid = int(self.get_xpath("/Event/EventData/Data[@Name='ProcessId']").text, 0x10)
         ppid = int(self.get_xpath("/Event/System/Execution").get("ProcessID"), 10)
+        cmdline = ""
         user = self.get_xpath("/Event/EventData/Data[@Name='SubjectUserName']").text
         domain = self.get_xpath("/Event/EventData/Data[@Name='SubjectDomainName']").text
         logonid = self.get_xpath("/Event/EventData/Data[@Name='SubjectLogonId']").text
         computer = self.get_xpath("/Event/System/Computer").text
-        p = Process(pid, ppid, path, user, domain, logonid, computer)
+        p = Process(pid, ppid, cmdline, path, user, domain, logonid, computer)
         p.end = self._record.timestamp()
         return p
 


### PR DESCRIPTION
KB3004375 added support for recording command line arguments in 4688 process tracking events. The update is automatic for Win7+, but the feature must be enabled. 

This update creates a new process information field in 4688 events named "Process Command Line", which contains the full command line from the process creation.

I modified the script slightly to include the process command line in the parsed output.
