### PR TITLE
parent process name update, bug fix

### DIFF
--- a/src/process_forest.py
+++ b/src/process_forest.py
@@ -92,7 +92,7 @@ class Entry(object):
         try:
             cmdline = self.get_xpath("/Event/EventData/Data[@Name='CommandLine']").text
         except:
-            cmdline = ""
+            cmdline = "UNKNOWN"
         try:
             ppname = self.get_xpath("/Event/EventData/Data[@Name='ParentProcessName']").text
         except:
@@ -109,7 +109,7 @@ class Entry(object):
         path = self.get_xpath("/Event/EventData/Data[@Name='ProcessName']").text
         pid = int(self.get_xpath("/Event/EventData/Data[@Name='ProcessId']").text, 0x10)
         ppid = int(self.get_xpath("/Event/System/Execution").get("ProcessID"), 10)
-        cmdline = ""
+        cmdline = "UNKNOWN"
         ppname = ""
         user = self.get_xpath("/Event/EventData/Data[@Name='SubjectUserName']").text
         domain = self.get_xpath("/Event/EventData/Data[@Name='SubjectDomainName']").text

--- a/src/process_forest.py
+++ b/src/process_forest.py
@@ -110,7 +110,7 @@ class Entry(object):
         pid = int(self.get_xpath("/Event/EventData/Data[@Name='ProcessId']").text, 0x10)
         ppid = int(self.get_xpath("/Event/System/Execution").get("ProcessID"), 10)
         cmdline = "UNKNOWN"
-        ppname = ""
+        ppname = "UNKNOWN"
         user = self.get_xpath("/Event/EventData/Data[@Name='SubjectUserName']").text
         domain = self.get_xpath("/Event/EventData/Data[@Name='SubjectDomainName']").text
         logonid = self.get_xpath("/Event/EventData/Data[@Name='SubjectLogonId']").text


### PR DESCRIPTION
There are three pieces to this update.

First, I changed the way that unknown command line arguments are recorded - displaying "UNKNOWN" instead of an empty string. I also added serialization for the command line, which I had overlooked.

Second, I added support for parent process name. Windows 10 added a ParentProcessName event log field in 4688 events. I used this field to supply the correct name to "fake parent process" objects.

Third, I identified a bug which resulted in some children of "fake parent process" objects being dropped from the process tree. I corrected this on line 183.
