### PR TITLE
Fix character decoding

### DIFF
--- a/src/process_forest.py
+++ b/src/process_forest.py
@@ -49,7 +49,7 @@ class Process(object):
 
     def __str__(self):
         return "Process(%s, cmd=%s, hashes=%s, pid=%x, ppid=%x, begin=%s, end=%s" % (
-                self.path, self.cmdline, self.hashes, self.pid, self.ppid,
+                repr(self.path), self.cmdline, self.hashes, self.pid, self.ppid,
                 self.begin.isoformat(), self.end.isoformat())
 
     # TODO: move serialize, deserialize here

--- a/src/process_forest.py
+++ b/src/process_forest.py
@@ -403,7 +403,7 @@ def summarize_processes(processes):
 
     print("path counts")
     for (path, count) in sorted(counts.items(), key=lambda p:p[1], reverse=True):
-        print("  - %s: %d" % (path, count))
+        print("  - %s: %d" % (repr(path), count))
     print("-------------------------")
 
     # TODO: seems to be broken due to timezones?


### PR DESCRIPTION
Fixes an error (python 2.7) when filename contains a non printable character.

Example : 
\Device\HarddiskVolume3\\xa0\Laptop\ChromeSetup.exe
