### PR TITLE
set lxml parser to utf-8

### DIFF
--- a/src/process_forest.py
+++ b/src/process_forest.py
@@ -21,8 +21,9 @@ def to_lxml(record_xml):
     """
     @type record: Record
     """
+    utf8_parser = etree.XMLParser(encoding='utf-8')
     return etree.fromstring("<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\" ?>%s" %
-            record_xml.replace("xmlns=\"http://schemas.microsoft.com/win/2004/08/events/event\"", ""))
+            record_xml.replace("xmlns=\"http://schemas.microsoft.com/win/2004/08/events/event\"", "").encode('utf-8'), parser=utf8_parser)
 
 
 class Process(object):
@@ -129,7 +130,7 @@ class Entry(object):
         p = Process(pid, ppid, cmdline, ppname, hashes, path, user, domain, logonid, computer)
         p.end = self._record.timestamp()
         return p
-        
+
     def get_process_from_1_event(self):
         path = self.get_xpath("/Event/EventData/Data[@Name='Image']").text
         pid = int(self.get_xpath("/Event/EventData/Data[@Name='ProcessId']").text, 0x10)
@@ -145,7 +146,7 @@ class Entry(object):
         p = Process(pid, ppid, cmdline, ppname, hashes, path, user, domain, logonid, computer)
         p.begin = self._record.timestamp()
         return p
-    
+
     def get_process_from_5_event(self):
         path = self.get_xpath("/Event/EventData/Data[@Name='Image']").text
         pid = int(self.get_xpath("/Event/EventData/Data[@Name='ProcessId']").text, 0x10)


### PR DESCRIPTION
This PR addresses https://github.com/williballenthin/process-forest/issues/9

## Before parser fix
### summary

`$ python process_forest.py bad_sysmon.evtx summary`
```
INFO:process-forest.global:using evtx log file
DEBUG:Evtx.Evtx:FILE HEADER at 0x0.
DEBUG:Evtx.Evtx:CHUNK HEADER at 0x1000.
DEBUG:Evtx.Evtx:Record at 0x1200.
Traceback (most recent call last):
  File "process_forest.py", line 483, in <module>
    main()
  File "process_forest.py", line 461, in main
    analyzer.analyze(get_entries_with_eids(evtx, set([4688, 4689, 1, 5])))
  File "process_forest.py", line 211, in analyze
    for entry in entries:
  File "process_forest.py", line 193, in get_entries_with_eids
    for entry in get_entries(evtx):
  File "process_forest.py", line 183, in get_entries
    yield Entry(xml, record)
  File "process_forest.py", line 73, in __init__
    self._node = to_lxml(self._xml)
  File "process_forest.py", line 25, in to_lxml
    record_xml.replace("xmlns=\"http://schemas.microsoft.com/win/2004/08/events/event\"", ""))
  File "src/lxml/lxml.etree.pyx", line 3213, in lxml.etree.fromstring (src/lxml/lxml.etree.c:79010)
  File "src/lxml/parser.pxi", line 1843, in lxml.etree._parseMemoryDocument (src/lxml/lxml.etree.c:118282)
ValueError: Unicode strings with encoding declaration are not supported. Please use bytes input or XML fragments without declaration.
```

### ts all
`$ python process_forest.py bad_sysmon.evtx summary`
```
INFO:process-forest.global:using evtx log file
DEBUG:Evtx.Evtx:FILE HEADER at 0x0.
DEBUG:Evtx.Evtx:CHUNK HEADER at 0x1000.
DEBUG:Evtx.Evtx:Record at 0x1200.
Traceback (most recent call last):
  File "process_forest.py", line 483, in <module>
    main()
  File "process_forest.py", line 461, in main
    analyzer.analyze(get_entries_with_eids(evtx, set([4688, 4689, 1, 5])))
  File "process_forest.py", line 211, in analyze
    for entry in entries:
  File "process_forest.py", line 193, in get_entries_with_eids
    for entry in get_entries(evtx):
  File "process_forest.py", line 183, in get_entries
    yield Entry(xml, record)
  File "process_forest.py", line 73, in __init__
    self._node = to_lxml(self._xml)
  File "sprocess_forest.py", line 25, in to_lxml
    record_xml.replace("xmlns=\"http://schemas.microsoft.com/win/2004/08/events/event\"", ""))
  File "src/lxml/lxml.etree.pyx", line 3213, in lxml.etree.fromstring (src/lxml/lxml.etree.c:79010)
  File "src/lxml/parser.pxi", line 1843, in lxml.etree._parseMemoryDocument (src/lxml/lxml.etree.c:118282)
ValueError: Unicode strings with encoding declaration are not supported. Please use bytes input or XML fragments without declaration.
```

## After parser fix
### summary
`$ python process-forest.py bad_sysmon.evtx summary`
```
INFO:process-forest.global:using evtx log file
DEBUG:Evtx.Evtx:FILE HEADER at 0x0.
DEBUG:Evtx.Evtx:CHUNK HEADER at 0x1000.
DEBUG:Evtx.Evtx:Record at 0x1200.
WARNING:process-forest.analyzer:missing start event for exiting process: 11008
DEBUG:Evtx.Evtx:Record at 0x19c0.
WARNING:process-forest.analyzer:missing start event for exiting process: 11460
DEBUG:Evtx.Evtx:Record at 0x1ba8.
WARNING:process-forest.analyzer:parent process 5136 not captured for new process 11188
DEBUG:Evtx.Evtx:Record at 0x2478.
DEBUG:Evtx.Evtx:Record at 0x28a0.
DEBUG:Evtx.Evtx:Record at 0x2a90.
DEBUG:Evtx.Evtx:Record at 0x2c78.
DEBUG:Evtx.Evtx:Record at 0x2e98.
WARNING:process-forest.analyzer:missing start event for exiting process: 11096
DEBUG:Evtx.Evtx:Record at 0x3080.
WARNING:process-forest.analyzer:parent process 10312 not captured for new process 8968
...
first event: 2017-03-12T10:03:55.272663
last event: 2017-03-13T19:32:15.723822
-------------------------
path counts
  - C:\Windows\System32\conhost.exe: 725
  - C:\Program Files\Windows Defender\MpCmdRun.exe: 411
  - C:\Windows\SysWOW64\dllhost.exe: 390
...
```

### ts all
`$ python process-forest.py bad_sysmon.evtx ts all`
```
INFO:process-forest.global:using evtx log file
DEBUG:Evtx.Evtx:FILE HEADER at 0x0.
DEBUG:Evtx.Evtx:CHUNK HEADER at 0x1000.
DEBUG:Evtx.Evtx:Record at 0x1200.
WARNING:process-forest.analyzer:missing start event for exiting process: 11008
DEBUG:Evtx.Evtx:Record at 0x19c0.
WARNING:process-forest.analyzer:missing start event for exiting process: 11460
DEBUG:Evtx.Evtx:Record at 0x1ba8.
WARNING:process-forest.analyzer:parent process 5136 not captured for new process 11188
...
    Process(C:\Windows\System32\conhost.exe, cmd=\??\C:\Windows\system32\conhost.exe 0xffffffff, hashes=SHA1=<a hash>, pid=2072, ppid=9408, begin=2017-03-12T14:00:40.281836, end=2017-03-12T14:00:40.585684
...
```